### PR TITLE
feat: Pre-fetch events to fix Vercel deployment

### DIFF
--- a/src/modules/events/context.tsx
+++ b/src/modules/events/context.tsx
@@ -38,8 +38,14 @@ interface IEventsContext {
 
 const EventsContext = createContext<IEventsContext | null>(null);
 
-export const EventsProvider = ({ children }: { children: ReactNode }) => {
-  const [events, setEvents] = useState<IEvent[]>([]);
+export const EventsProvider = ({
+  children,
+  initialEvents = [],
+}: {
+  children: ReactNode;
+  initialEvents?: IEvent[];
+}) => {
+  const [events, setEvents] = useState<IEvent[]>(initialEvents);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [filters, setFilters] = useState<IEventFilters>({
@@ -92,9 +98,11 @@ export const EventsProvider = ({ children }: { children: ReactNode }) => {
   );
 
   useEffect(() => {
-    fetchEvents(filters, 0);
+    if (initialEvents.length === 0) {
+      fetchEvents(filters, 0);
+    }
     setSkip(0);
-  }, [filters, fetchEvents]);
+  }, [filters, fetchEvents, initialEvents]);
 
   const handleSetFilters = useCallback(
     (newFilters: Partial<IEventFilters>) => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import '@/styles/globals.css';
 import 'leaflet/dist/leaflet.css';
-import type { AppProps } from 'next/app';
+import type { AppContext, AppInitialProps, AppProps } from 'next/app';
+import App from 'next/app';
 import { AuthProvider } from '@/context/AuthContext';
 import { EventsProvider } from '@/modules/events/context';
 import { SubmitProvider } from '@/modules/submit/context';
@@ -8,11 +9,13 @@ import { DashboardProvider } from '@/modules/dashboard/context';
 import { AdminProvider } from '@/modules/admin/context';
 import { ToastProvider } from '@/components/ToastProvider';
 import { NotificationsProvider } from '@/modules/notifications/context';
+import { IEvent } from '@/modules/events/model';
+import { apiClient } from '@/lib/api';
 
-export default function App({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps, events }: AppProps & { events: IEvent[] }) {
   return (
     <AuthProvider>
-      <EventsProvider>
+      <EventsProvider initialEvents={events}>
         <SubmitProvider>
           <DashboardProvider>
             <AdminProvider>
@@ -27,3 +30,25 @@ export default function App({ Component, pageProps }: AppProps) {
     </AuthProvider>
   );
 }
+
+MyApp.getInitialProps = async (
+  context: AppContext
+): Promise<AppInitialProps & { events: IEvent[] }> => {
+  const ctx = await App.getInitialProps(context);
+  let events: IEvent[] = [];
+
+  try {
+    const { data } = await apiClient.get<{ data: IEvent[] }>("/events", {
+      params: { limit: 10, skip: 0 },
+    });
+    if (data.data) {
+      events = data.data;
+    }
+  } catch (error) {
+    console.error("Error fetching events in _app.tsx:", error);
+  }
+
+  return { ...ctx, events };
+};
+
+export default MyApp;


### PR DESCRIPTION
Modified `_app.tsx` to use `getInitialProps` to fetch events on the server-side. This ensures that data is available during the initial render and prevents the application from crashing on Vercel.

Updated `EventsProvider` to accept `initialEvents` and avoid re-fetching on the client-side if data is already present.